### PR TITLE
[#37] 릴리즈 시 JSDelivr 캐시 초기화

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,3 +71,12 @@ jobs:
       with:
         files: |
           dist/Pretendard-${{ env.RELEASE_NAME }}.zip
+
+  cache-invalidation:
+    needs: upload
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Purge JSDelivr cache
+      run: |
+        https://purge.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static


### PR DESCRIPTION
- `cache-invalidation`이라는 Job을 추가하였습니다.